### PR TITLE
Fix adding non valued options

### DIFF
--- a/grub
+++ b/grub
@@ -128,7 +128,7 @@ class Grub(object):
     def _kernel_options_tostring(self, options):
         t = []
         for key, val in options:
-            if val == '':
+            if val == '' or val == None:
                 t.append(key)
             else:
                 t.append('%s=%s' % (key, val))


### PR DESCRIPTION
Without this fix "grub: state=present koption=quiet" leads to "grub=None".
Kvalue is initialized as "None" but is checked only against ''
