### PR TITLE
Fix logic when handling possible doublicates (i.e. rd.lvm.lv)

### DIFF
--- a/grub
+++ b/grub
@@ -116,7 +116,7 @@ class Grub(object):
                     aval = v.partition("=")[2]
             
                 replaced = False
-                if akey not in allow_multi or akey[:1] != '$':
+                if akey not in allow_multi and akey[:1] != '$':
                     for i, el in enumerate(r):
                         if el[0] == akey and el[0]:
                             r[i] = (akey, aval)


### PR DESCRIPTION
The logic should be: "allowed duplicates _OR_ executes (starts with '$') should simply be appended". In the current code, 'rd.lvm.lv' is in allow_multi, but does not start with '$', so a replace will be tried. At first we still hit the append, because it does not exists, after that, that last occurrence of 'rd.lvm.lv' will made it to the string.
