### PR TITLE
Add 'allow_multi' parameter.

### DIFF
--- a/grub
+++ b/grub
@@ -50,6 +50,12 @@ options:
     description:
       - Add a value to the specified kernel option. If there's no value associated to 
         the option, then ommit this argument.
+
+  allow_multi:
+    required: false
+    choices: [ yes, no ]
+    description:
+      - Whether an option can be defined multiple times
     
 """
 
@@ -77,6 +83,7 @@ class Grub(object):
         self.timeout   = module.params['timeout']
         self.koption    = module.params['koption']
         self.kvalue     = module.params['kvalue']
+        self.allow_multi = module.params['allow_multi']
 
         self.grub_bin_install  = None
         self.grub_bin_mkconfig = None
@@ -105,7 +112,6 @@ class Grub(object):
     def _kernel_options_tolist(self, options):
         t = re.findall(r'([^\s]*=\$\([^\(]*\)|\$\([^\(]*\)|[^\s]*)', options)
         r = []
-        allow_multi = [ 'rd.lvm.lv' ]
         for v in t:
             if v != '':
                 if v.find('$(') >= 0 and v.find('$(') < v.find("="):
@@ -116,7 +122,7 @@ class Grub(object):
                     aval = v.partition("=")[2]
             
                 replaced = False
-                if akey not in allow_multi and akey[:1] != '$':
+                if akey == self.koption and self.allow_multi is not True and akey[:1] != '$':
                     for i, el in enumerate(r):
                         if el[0] == akey and el[0]:
                             r[i] = (akey, aval)
@@ -138,14 +144,23 @@ class Grub(object):
 
     def _kernel_remove_option(self, options):
         t = self._kernel_options_tolist(options)
-        t = [ (key, val) for key, val in t if key != self.koption ]
+        t = [ (key, val) for key, val in t if key != self.koption or ( key == self.koption and val != self.kvalue ) ]
         return self._kernel_options_tostring(t)
 
     def _kernel_set_option(self, options):
         t = self._kernel_options_tolist(options)
+
+        found = False
+        for i, el in enumerate(t):
+            if el[0] == self.koption and el[1] == self.kvalue:
+                found = True
+        if found is True:
+            return self._kernel_options_tostring(t)
+
         replaced = False
         for i, el in enumerate(t):
-            if el[0] == self.koption:
+            found = False
+            if el[0] == self.koption and self.allow_multi is not True:
                 t[i] = (el[0], self.kvalue)
                 replaced = True
         if replaced is not True:
@@ -403,6 +418,7 @@ def main():
             timeout   = dict(default = None, type = 'int'),
             koption    = dict(default = None, type = 'str'),
             kvalue     = dict(default = None, type = 'str'),
+            allow_multi = dict(default = False, type = 'bool'),
         ),
         supports_check_mode = False
     )


### PR DESCRIPTION
This replaces the hardcoded list of kernel options which
are allowed to be duplicated, and actually allows this
module to add the duplicate entries.

This is useful e.g. to be able to add several console= options, to have boot output sent to different serial ports in addition to tty0.

It will break existing playbooks which rely on the "rd.lvm.lv" option getting special handling. Those will need to be updated.